### PR TITLE
STORY-6805 change history remove stub data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "aggregate",         "~> 1.1.0", git: "git@github.com:Invoca/aggregate.git",         ref: "8199a17bd50b5dc34e094f1f2646b6c5e3ad1ddc"
+gem "aggregate",         "~> 1.0.1", git: "git@github.com:Invoca/aggregate.git",         ref: "4644394a818295f240f22ae2cee2a92a9fd4f605"
 gem "hobo_support",         "2.0.1", git: "git@github.com:Invoca/hobosupport",           ref: "b9086322274b474a2b5bae507c4885e55d4aa050"
 gem "large_text_field",              git: "git@github.com:Invoca/large_text_field.git",  ref: "2efc950395352bf8b7f45891122f6bc42b171526"
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "aggregate",         "~> 0.2.0", git: "git@github.com:Invoca/aggregate.git",         ref: "b3fd4f570e6d7530a088333892569ce47b570a85"
+gem "aggregate",         "~> 1.1.0", git: "git@github.com:Invoca/aggregate.git",         ref: "8199a17bd50b5dc34e094f1f2646b6c5e3ad1ddc"
 gem "hobo_support",         "2.0.1", git: "git@github.com:Invoca/hobosupport",           ref: "b9086322274b474a2b5bae507c4885e55d4aa050"
 gem "large_text_field",              git: "git@github.com:Invoca/large_text_field.git",  ref: "2efc950395352bf8b7f45891122f6bc42b171526"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: git@github.com:Invoca/aggregate.git
-  revision: 8199a17bd50b5dc34e094f1f2646b6c5e3ad1ddc
-  ref: 8199a17bd50b5dc34e094f1f2646b6c5e3ad1ddc
+  revision: 4644394a818295f240f22ae2cee2a92a9fd4f605
+  ref: 4644394a818295f240f22ae2cee2a92a9fd4f605
   specs:
-    aggregate (1.1.0)
+    aggregate (1.0.1)
       activerecord (~> 4.0)
       encryptor (~> 3.0)
       hobo_support (= 2.0.1)
@@ -195,7 +195,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aggregate (~> 1.1.0)!
+  aggregate (~> 1.0.1)!
   bundler (~> 1.16)
   elasticsearch-extensions
   elasticsearch_models!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: git@github.com:Invoca/aggregate.git
-  revision: b3fd4f570e6d7530a088333892569ce47b570a85
-  ref: b3fd4f570e6d7530a088333892569ce47b570a85
+  revision: 8199a17bd50b5dc34e094f1f2646b6c5e3ad1ddc
+  ref: 8199a17bd50b5dc34e094f1f2646b6c5e3ad1ddc
   specs:
-    aggregate (0.2.0)
+    aggregate (1.1.0)
       activerecord (~> 4.0)
       encryptor (~> 3.0)
       hobo_support (= 2.0.1)
@@ -30,7 +30,7 @@ GIT
 PATH
   remote: .
   specs:
-    elasticsearch_models (0.2.1)
+    elasticsearch_models (0.2.2)
       activesupport
       elasticsearch (= 6.1.0)
       hobo_support (= 2.0.1)
@@ -195,7 +195,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aggregate (~> 0.2.0)!
+  aggregate (~> 1.1.0)!
   bundler (~> 1.16)
   elasticsearch-extensions
   elasticsearch_models!

--- a/README.md
+++ b/README.md
@@ -191,3 +191,13 @@ DummyDailyIndexModel.where(_indices: ["dummy_daily_index.19.01.04", "dummy_daily
 DummyDailyIndexModel.where(_indices: "wrong_index_name").models
 => []
 ```
+
+### Retrieving Count of Documents
+If you only need to query for the count of documents, you can call `.count` with normal query params. The count will be the return value.
+
+Note: You will need to exclude `_size`, `_from`, and `_sort_by` params.
+
+```ruby
+
+DummyElasticSearchModel.count(my_string: "Hi", my_int: 2) # => 2
+```

--- a/lib/elasticsearch_models/base.rb
+++ b/lib/elasticsearch_models/base.rb
@@ -37,9 +37,11 @@ module ElasticsearchModels
       end
 
       def where(**params)
-        params_with_indices = params[:_indices] ? params : params.merge(_indices: index_name)
-        search_params = Query::Builder.new(params_with_indices.merge(query_types: type)).search_params
-        Query::Response.new(client_connection.search(search_params))
+        Query::Response.new(client_connection.search(query_params(**params)))
+      end
+
+      def count(**params)
+        client_connection.count(query_params(**params))["count"]
       end
 
       def client_connection
@@ -63,6 +65,13 @@ module ElasticsearchModels
       def query_types
         class_names = ancestors.select { |ancestor| ancestor.is_a?(Class) }
         class_names.take_while { |klass| klass != ElasticsearchModels::Base }.map(&:name) # returns all parent classes up to ElasticsearchModels::Base
+      end
+
+      private
+
+      def query_params(**params)
+        params_with_indices = params[:_indices] ? params : params.merge(_indices: index_name)
+        Query::Builder.new(params_with_indices.merge(query_types: type)).search_params
       end
     end
 

--- a/lib/elasticsearch_models/query/builder.rb
+++ b/lib/elasticsearch_models/query/builder.rb
@@ -6,15 +6,16 @@ module ElasticsearchModels
       def initialize(**params)
         @indices = params.delete(:_indices)
 
-        @size       = params.delete(:_size)
-        @from       = params.delete(:_from)
-        @sort_by    = params.delete(:_sort_by)
+        @size               = params.delete(:_size)
+        @from               = params.delete(:_from)
+        @sort_by            = params.delete(:_sort_by)
+        @ignore_unavailable = params.delete(:_ignore_unavailable)
 
         @params = params.compact
       end
 
       def search_params
-        { index: @indices, size: @size, from: @from, body: search_body }.compact
+        { index: @indices, size: @size, from: @from, ignore_unavailable: @ignore_unavailable, body: search_body }.compact
       end
 
       private

--- a/lib/elasticsearch_models/version.rb
+++ b/lib/elasticsearch_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ElasticsearchModels
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/spec/query/builder_spec.rb
+++ b/spec/query/builder_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe ElasticsearchModels::Query::Builder do
         expect(new_builder(_from: 99).search_params).to eq(expected_params)
       end
 
+      it "includes _ignore_unavailable when given" do
+        expected_params = @default_expected_params.merge(ignore_unavailable: true)
+        expect(new_builder(_ignore_unavailable: true).search_params).to eq(expected_params)
+      end
+
       context "_sort_by" do
         before(:each) do
           @expected_bool_body = {


### PR DESCRIPTION
## Details
* Add `_ignore_unavailable` query option to ignore non-existent indexes.
* Add `ElasticsearchModels::Base.count` to use Elasticsearch's `count` api with `Query::Builder` params.