### PR TITLE
1903/story 7120 term aggregation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,10 @@ DummyElasticSearchModel.where(_aggs: { field: "my_string.keyword", size: 2 })
 DummyElasticSearchModel.where(_aggs: { field: "my_string.keyword", order: "_key" })
 
 # Aggregate on a single field with ordering on a different field in a different direction
-DummyElasticSearchModel.where(_aggs: { field: "my_string.keyword", order: ["_key", "asc"] })
+DummyElasticSearchModel.where(_aggs: { field: "my_string.keyword", order: { "_key" => "asc" } })
+
+# Aggregate on a single field with multiple ordering options
+DummyElasticSearchModel.where(_aggs: { field: "my_string.keyword", order: ["_key", { "_count" => "asc" }] })
 
 # Aggregate on a single field with sub-aggregations (supports infinite nestings)
 DummyElasticSearchModel.where(_aggs: { field: "my_string.keyword", aggs: "my_id" })
@@ -284,9 +287,8 @@ DummyElasticSearchModel.distinct_values("my_string.keyword", where: { _q: { "Hey
 
 # Distinct Values for single term with order
 DummyElasticSearchModel.distinct_values("my_string.keyword", order: "_key")
-DummyElasticSearchModel.distinct_values("my_string.keyword", order: "_count")
-DummyElasticSearchModel.distinct_values("my_string.keyword", order: ["_count", "asc"])
-DummyElasticSearchModel.distinct_values("my_string.keyword", order: ["_key", "asc"])
+DummyElasticSearchModel.distinct_values("my_string.keyword", order: { "_count" => "asc" })
+DummyElasticSearchModel.distinct_values("my_string.keyword", order: ["_key", { "_count" => "asc" }])
 
 # Distinct Values with partition
 DummyElasticSearchModel.distinct_values("my_string.keyword", partition: 0, num_partitions: 2)

--- a/lib/elasticsearch_models.rb
+++ b/lib/elasticsearch_models.rb
@@ -14,6 +14,7 @@ require 'elasticsearch_models/deep_squash'
 require 'elasticsearch_models/aggregate'
 require 'elasticsearch_models/base'
 
+require 'elasticsearch_models/query/aggregations'
 require 'elasticsearch_models/query/aggregation_term'
 require 'elasticsearch_models/query/builder'
 require 'elasticsearch_models/query/response'

--- a/lib/elasticsearch_models.rb
+++ b/lib/elasticsearch_models.rb
@@ -14,6 +14,7 @@ require 'elasticsearch_models/deep_squash'
 require 'elasticsearch_models/aggregate'
 require 'elasticsearch_models/base'
 
+require 'elasticsearch_models/query/aggregation_term'
 require 'elasticsearch_models/query/builder'
 require 'elasticsearch_models/query/response'
 require 'elasticsearch_models/query/helper'

--- a/lib/elasticsearch_models/query/aggregation_term.rb
+++ b/lib/elasticsearch_models/query/aggregation_term.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module ElasticsearchModels
+  module Query
+    class AggregationTerm
+      attr_reader :field, :term
+
+      DEFAULT_ORDER_BY = "_count"
+      DEFAULT_ORDER_DIRECTION = "desc"
+
+      def initialize(field:, size: nil, order: nil, partition: nil, num_partitions: nil)
+        @field = field.presence or raise ArgumentError, "field must be provided"
+
+        @size    = size
+        @order   = order_term(order)
+        @include = { partition: partition, num_partitions: num_partitions }.compact.presence
+        @term    = _term
+      end
+
+      private
+
+      def _term
+        {
+          field => {
+            terms: {
+              field:   field,
+              size:    @size,
+              order:   @order,
+              include: @include
+            }.compact
+          }
+        }
+      end
+
+      def order_term(order)
+        order_by, order_direction =
+          case order.presence
+          when String
+            [order, DEFAULT_ORDER_DIRECTION]
+          when Array
+            order.size > 2 and raise ArgumentError, "order provided as an Array with more than 2 elements. Expected 1..2"
+            [order[0], order[1] || DEFAULT_ORDER_DIRECTION]
+          when nil
+            [DEFAULT_ORDER_BY, DEFAULT_ORDER_DIRECTION]
+          else
+            raise ArgumentError, "unexpected value for order: got #{order.inspect}"
+          end
+        { order_by => order_direction }
+      end
+    end
+  end
+end

--- a/lib/elasticsearch_models/query/aggregation_term.rb
+++ b/lib/elasticsearch_models/query/aggregation_term.rb
@@ -12,7 +12,7 @@ module ElasticsearchModels
         @field = field.presence or raise ArgumentError, "field must be provided"
 
         @size    = size
-        @order   = order_term(order)
+        @order   = Array.wrap(order).flatten.map { |term| order_term(term) }.compact.presence
         @include = { partition: partition, num_partitions: num_partitions }.compact.presence
         @term    = _term
       end
@@ -33,19 +33,14 @@ module ElasticsearchModels
       end
 
       def order_term(order)
-        order_by, order_direction =
-          case order.presence
-          when String
-            [order, DEFAULT_ORDER_DIRECTION]
-          when Array
-            order.size > 2 and raise ArgumentError, "order provided as an Array with more than 2 elements. Expected 1..2"
-            [order[0], order[1] || DEFAULT_ORDER_DIRECTION]
-          when nil
-            [DEFAULT_ORDER_BY, DEFAULT_ORDER_DIRECTION]
-          else
-            raise ArgumentError, "unexpected value for order: got #{order.inspect}"
-          end
-        { order_by => order_direction }
+        case order.presence
+        when String
+          { order => DEFAULT_ORDER_DIRECTION }
+        when Hash, nil
+          order
+        else
+          raise ArgumentError, "unexpected value for order: got #{order.inspect}"
+        end
       end
     end
   end

--- a/lib/elasticsearch_models/query/aggregations.rb
+++ b/lib/elasticsearch_models/query/aggregations.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module ElasticsearchModels
+  module Query
+    class Aggregations
+      class << self
+        def terms_for(condition)
+          { aggs: internal_terms_for(condition) }
+        end
+
+        private
+
+        def internal_terms_for(condition)
+          condition = condition.dup
+          case condition
+          when String
+            term_for_string(condition)
+          when Array
+            term_for_array(condition)
+          when Hash
+            term_for_hash(condition)
+          else
+            raise ArgumentError, "unexpected condition type: got #{condition.inspect}"
+          end
+        end
+
+        def term_for_string(condition)
+          AggregationTerm.new(field: condition).term
+        end
+
+        def term_for_array(conditions)
+          conditions.flatten.each_with_object({}) do |condition, aggs|
+            term  = internal_terms_for(condition)
+            field = term.keys.first
+            aggs.key?(field) and raise ArgumentError, "duplicate field aggregation provided for #{field.inspect}"
+            aggs.merge!(term)
+          end
+        end
+
+        def term_for_hash(condition)
+          sub_aggs = condition.delete(:aggs)
+          AggregationTerm.new(condition).term.tap do |agg|
+            agg.values.first.merge!(terms_for(sub_aggs)) if sub_aggs
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/elasticsearch_models/query/builder.rb
+++ b/lib/elasticsearch_models/query/builder.rb
@@ -7,6 +7,7 @@ module ElasticsearchModels
         @indices = params.delete(:_indices)
 
         @q                  = params.delete(:_q)
+        @aggs               = params.delete(:_aggs).presence
         @size               = params.delete(:_size)
         @from               = params.delete(:_from)
         @sort_by            = params.delete(:_sort_by)
@@ -22,7 +23,15 @@ module ElasticsearchModels
       private
 
       def body
-        [match_query_body, sort_body].reduce(&:merge).presence
+        [match_query_body, sort_body, aggs_body].reduce(&:merge).presence
+      end
+
+      def aggs_body
+        if @aggs
+          Aggregations.terms_for(@aggs)
+        else
+          {}
+        end
       end
 
       def search_query

--- a/lib/elasticsearch_models/query/response.rb
+++ b/lib/elasticsearch_models/query/response.rb
@@ -10,10 +10,11 @@ class ElasticsearchModels::Query::Response
     end
   end
 
-  attr_reader :models, :raw_response, :errors
+  attr_reader :models, :raw_response, :errors, :aggregations
 
   def initialize(raw_response)
     @raw_response    = raw_response
+    @aggregations    = raw_response["aggregations"]
     @models, @errors = parse_raw_response
   end
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -1294,11 +1294,19 @@ RSpec.describe ElasticsearchModels::Base do
           end
         end
 
-        context "as an Array with elements defining sort field and sort order" do
-          let(:order) { ["_term", "asc"] }
+        context "as a Hash" do
+          let(:order) { { "_term" => "asc" } }
 
           it "orders response by provided option" do
             expect(distinct_values).to eq("my_string.keyword" => ["Hello", "Hello again", "Hey", "How are you?", "This is a test"])
+          end
+        end
+
+        context "as an array with multiple order terms" do
+          let(:order) { [{ "_count" => "desc" }, { "_term" => "desc" }] }
+
+          it "orders response by provided option" do
+            expect(distinct_values).to eq("my_string.keyword" => ["This is a test", "Hello", "How are you?", "Hey", "Hello again"])
           end
         end
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -1156,5 +1156,210 @@ RSpec.describe ElasticsearchModels::Base do
         end
       end
     end
+
+    describe ".distinct_values" do
+      subject(:distinct_values) { DummyElasticSearchModel.distinct_values(field, options) }
+      let(:field) { "my_string.keyword" }
+      let(:options) do
+        {
+          additional_fields: additional_fields,
+          order:             order,
+          size:              size,
+          partition:         partition,
+          num_partitions:    num_partitions,
+          where:             where
+        }.compact
+      end
+      let(:additional_fields) { }
+      let(:order) { }
+      let(:size) { }
+      let(:partition) { }
+      let(:num_partitions) { }
+      let(:where) { }
+
+      before :each do
+        DummyElasticSearchModel.create!(my_string: "Hey", my_int: 0, my_bool: true)
+        DummyElasticSearchModel.create!(my_string: "Hello", my_int: 1)
+        DummyElasticSearchModel.create!(my_string: "This is a test", my_int: 2)
+        DummyElasticSearchModel.create!(my_string: "This is a test", my_int: 2)
+        DummyElasticSearchModel.create!(my_string: "Hello", my_int: 3, my_bool: true)
+        DummyElasticSearchModel.create!(my_string: "Hello again", my_int: 4, my_bool: true)
+        DummyElasticSearchModel.create!(my_string: "How are you?", my_other_string: "found by fuzzy matching", my_int: 5)
+
+        refresh_index
+      end
+
+      context "when field is not aggregateable" do
+        let(:field) { "my_string" }
+
+        it "raises Elasticsearch BadRequest" do
+          error = raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest, /Fielddata is disabled on text fields by default/)
+          expect { distinct_values }.to error
+        end
+      end
+
+      context "field provided is a string" do
+        it "returns all distinct values for the provided field in hash form" do
+          expect(distinct_values).to eq("my_string.keyword" => ["Hello", "This is a test", "Hello again", "Hey", "How are you?"])
+        end
+      end
+
+      context "field provided is empty" do
+        let(:field) { "" }
+
+        it "returns ArgumentError if not provided with a string" do
+          expect { distinct_values }.to raise_error(ArgumentError, "field must be a present String")
+        end
+      end
+
+      context "field provided is not a string" do
+        let(:field) { {} }
+
+        it "returns ArgumentError if not provided with a string" do
+          expect { distinct_values }.to raise_error(ArgumentError, "field must be a present String")
+        end
+      end
+
+      context "with :additional_fields option" do
+        let(:additional_fields) { ["my_int", "my_other_string.keyword"] }
+
+        it "returns all distinct values with nested values in hash form" do
+          # { field => { "response1" => [...], "response2" => [...] } }
+          expected_values = {
+            "my_string.keyword" => {
+              "This is a test" => {
+                "my_int" => [2],
+                "my_other_string.keyword" => []
+              },
+              "How are you?" => {
+                "my_int" => [5],
+                "my_other_string.keyword" => ["found by fuzzy matching"]
+              },
+              "Hey" => {
+                "my_int" => [0],
+                "my_other_string.keyword" => []
+              },
+              "Hello" => {
+                "my_int" => [1, 3],
+                "my_other_string.keyword" => []
+              },
+              "Hello again" => {
+                "my_int" => [4],
+                "my_other_string.keyword" => []
+              }
+            }
+          }
+          expect(distinct_values).to eq(expected_values)
+        end
+
+        context "but not all fields are present" do
+          let(:additional_fields) { ["my_int", ""] }
+
+          it "raises ArgumentError if any of the values provided are not strings" do
+            expect { distinct_values }.to raise_error(ArgumentError, "additional_fields must all be present Strings")
+          end
+        end
+
+        context "but not all fields are strings" do
+          let(:additional_fields) { ["my_int", 123] }
+
+          it "raises ArgumentError if any of the values provided are not strings" do
+            expect { distinct_values }.to raise_error(ArgumentError, "additional_fields must all be present Strings")
+          end
+        end
+      end
+
+      context "with :size option" do
+        let(:size) { 2 }
+
+        it "returns only that number of distinct fields" do
+          expect(distinct_values).to eq("my_string.keyword" => ["Hello", "This is a test"])
+        end
+      end
+
+      context "with :order option" do
+        context "as a String" do
+          let(:order) { "_term" }
+
+          it "orders response by provided option" do
+            expect(distinct_values).to eq("my_string.keyword" => ["This is a test", "How are you?", "Hey", "Hello again", "Hello"])
+          end
+        end
+
+        context "as an Array with a single element defining sort field" do
+          let(:order) { ["_term"] }
+
+          it "orders response by provided option" do
+            expect(distinct_values).to eq("my_string.keyword" => ["This is a test", "How are you?", "Hey", "Hello again", "Hello"])
+          end
+        end
+
+        context "as an Array with elements defining sort field and sort order" do
+          let(:order) { ["_term", "asc"] }
+
+          it "orders response by provided option" do
+            expect(distinct_values).to eq("my_string.keyword" => ["Hello", "Hello again", "Hey", "How are you?", "This is a test"])
+          end
+        end
+
+        context "as an invalid option" do
+          let(:order) { "not orderable" }
+
+          it "raises Elasticsearch error" do
+            error = raise_error(Elasticsearch::Transport::Transport::Errors::InternalServerError, /Unknown aggregation \[not orderable\]/)
+            expect { distinct_values }.to error
+          end
+        end
+      end
+
+      context "with :partition provided alone" do
+        let(:partition) { 0 }
+
+        it "raises Elasticsearch error" do
+          error = raise_error(
+            Elasticsearch::Transport::Transport::Errors::BadRequest,
+            /Missing \[num_partitions\] parameter for partition-based include/
+          )
+          expect { distinct_values }.to error
+        end
+      end
+
+      context "with :num_partitions provided alone" do
+        let(:num_partitions) { 10 }
+
+        it "raises Elasticsearch error" do
+          error = raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest, /Missing \[partition\] parameter for partition-based include/)
+          expect { distinct_values }.to error
+        end
+      end
+
+      context "with :partition and :num_partitions provided" do
+        let(:partition) { 0 }
+        let(:num_partitions) { 2 }
+
+        it "allows for partitioned responses" do
+          expect(distinct_values).to eq("my_string.keyword" => ["Hello", "This is a test", "Hello again", "How are you?"])
+          expect(DummyElasticSearchModel.distinct_values(field, options.merge(partition: 1))).to eq("my_string.keyword" => ["Hey"])
+        end
+      end
+
+      context "with :where param" do
+        context "provided with a search query (_q param)" do
+          let(:where) { { _q: "fuzzy" } }
+
+          it "filters down responses" do
+            expect(distinct_values).to eq("my_string.keyword" => ["How are you?"])
+          end
+        end
+
+        context "provided with AND/OR matches" do
+          let(:where) { { my_int: 1..4, my_bool: true } }
+
+          it "filters down matches" do
+            expect(distinct_values).to eq("my_string.keyword" => ["Hello", "Hello again"])
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/query/aggregation_term_spec.rb
+++ b/spec/query/aggregation_term_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+RSpec.describe ElasticsearchModels::Query::AggregationTerm do
+  let(:options) { { field: field, size: size, order: order, partition: partition, num_partitions: num_partitions }.compact }
+  let(:field) { "some.field.keyword" }
+  let(:size) { }
+  let(:order) { }
+  let(:partition) { }
+  let(:num_partitions) { }
+
+  describe "#initialize" do
+    subject(:aggregation) { ElasticsearchModels::Query::AggregationTerm.new(options) }
+
+    it { should be }
+    it { should have_attributes(field: field) }
+
+    context "when field is provided" do
+      context "as empty string" do
+        let(:field) { "" }
+
+        it "raises ArgumentError" do
+          expect { aggregation }.to raise_error(ArgumentError, "field must be provided")
+        end
+      end
+
+      context "as nil" do
+        subject(:aggregation) { ElasticsearchModels::Query::AggregationTerm.new(options.merge(field: nil)) }
+
+        it "raises ArgumentError" do
+          expect { aggregation }.to raise_error(ArgumentError, "field must be provided")
+        end
+      end
+    end
+
+    context "when size is provided" do
+      let(:size) { 10_000 }
+      it { should be }
+    end
+
+    context "when order is provided" do
+      context "as a string" do
+        let(:order) { "_key" }
+        it { should be }
+      end
+
+      context "as an array" do
+        let(:order) { ["_key"] }
+        it { should be }
+
+        context "with more than two elements" do
+          let(:order) { ["_key", "and", "more"] }
+
+          it "should raise an ArgumentError" do
+            expect { aggregation }.to raise_error(ArgumentError, "order provided as an Array with more than 2 elements. Expected 1..2")
+          end
+        end
+      end
+
+      context "as anything else" do
+        let(:order) { { not: :valid } }
+        it "should raise an ArgumentError" do
+          expect { aggregation }.to raise_error(ArgumentError, "unexpected value for order: got {:not=>:valid}")
+        end
+      end
+    end
+
+    context "when partition is provided" do
+      let(:partition) { 10 }
+      it { should be }
+    end
+
+    context "when num_partitions is provided" do
+      let(:num_partitions) { 10 }
+      it { should be }
+    end
+  end
+
+  describe "#term" do
+    subject(:term) { aggregation.term }
+    let(:aggregation) { ElasticsearchModels::Query::AggregationTerm.new(options) }
+    let(:expected_term) { { field => { terms: expected_inner_terms } } }
+    let(:expected_inner_terms) { { field: "some.field.keyword", order: { "_count" => "desc" } } }
+
+    it { should eq(expected_term) }
+
+    context "when size is provided" do
+      let(:size) { 10_000 }
+      let(:expected_inner_terms) { { field: "some.field.keyword", order: { "_count" => "desc" }, size: 10_000 } }
+
+      it "includes the size in the inner terms" do
+        expect(term).to eq(expected_term)
+      end
+    end
+
+    context "when order is provided" do
+      context "as a string" do
+        let(:order) { "_key" }
+        let(:expected_inner_terms) { { field: "some.field.keyword", order: { "_key" => "desc" } } }
+
+        it "orders by provided field with a default sort direction" do
+          expect(term).to eq(expected_term)
+        end
+      end
+
+      context "as an array" do
+        context "with a single element" do
+          let(:order) { ["_key"] }
+          let(:expected_inner_terms) { { field: "some.field.keyword", order: { "_key" => "desc" } } }
+
+          it "orders by provided term with a default sort direction" do
+            expect(term).to eq(expected_term)
+          end
+        end
+
+        context "with two elements" do
+          let(:order) { ["_key", "asc"] }
+          let(:expected_inner_terms) { { field: "some.field.keyword", order: { "_key" => "asc" } } }
+
+          it "orders by provided term and sorts by the provided sort direction" do
+            expect(term).to eq(expected_term)
+          end
+        end
+      end
+    end
+
+    context "partition is provided" do
+      let(:partition) { 1 }
+      let(:expected_inner_terms) { { field: "some.field.keyword", order: { "_count" => "desc" }, include: { partition: 1 } } }
+
+      it "nests partition under include key within inner terms" do
+        expect(term).to eq(expected_term)
+      end
+    end
+
+    context "num_partitions is provided" do
+      let(:num_partitions) { 1 }
+      let(:expected_inner_terms) { { field: "some.field.keyword", order: { "_count" => "desc" }, include: { num_partitions: 1 } } }
+
+      it "nests num_partitions under include key" do
+        expect(term).to eq(expected_term)
+      end
+    end
+
+    context "partition and num_partitions are provided within inner terms" do
+      let(:partition) { 1 }
+      let(:num_partitions) { 1 }
+      let(:expected_inner_terms) { { field: "some.field.keyword", order: { "_count" => "desc" }, include: { partition: 1, num_partitions: 1 } } }
+
+      it "nests values under include key within inner terms" do
+        expect(term).to eq(expected_term)
+      end
+    end
+  end
+end

--- a/spec/query/aggregation_term_spec.rb
+++ b/spec/query/aggregation_term_spec.rb
@@ -46,20 +46,17 @@ RSpec.describe ElasticsearchModels::Query::AggregationTerm do
       context "as an array" do
         let(:order) { ["_key"] }
         it { should be }
+      end
 
-        context "with more than two elements" do
-          let(:order) { ["_key", "and", "more"] }
-
-          it "should raise an ArgumentError" do
-            expect { aggregation }.to raise_error(ArgumentError, "order provided as an Array with more than 2 elements. Expected 1..2")
-          end
-        end
+      context "as a hash" do
+        let(:order) { { "_key" => "asc" } }
+        it { should be }
       end
 
       context "as anything else" do
-        let(:order) { { not: :valid } }
+        let(:order) { 1 }
         it "should raise an ArgumentError" do
-          expect { aggregation }.to raise_error(ArgumentError, "unexpected value for order: got {:not=>:valid}")
+          expect { aggregation }.to raise_error(ArgumentError, "unexpected value for order: got 1")
         end
       end
     end
@@ -79,13 +76,13 @@ RSpec.describe ElasticsearchModels::Query::AggregationTerm do
     subject(:term) { aggregation.term }
     let(:aggregation) { ElasticsearchModels::Query::AggregationTerm.new(options) }
     let(:expected_term) { { field => { terms: expected_inner_terms } } }
-    let(:expected_inner_terms) { { field: "some.field.keyword", order: { "_count" => "desc" } } }
+    let(:expected_inner_terms) { { field: "some.field.keyword" } }
 
     it { should eq(expected_term) }
 
     context "when size is provided" do
       let(:size) { 10_000 }
-      let(:expected_inner_terms) { { field: "some.field.keyword", order: { "_count" => "desc" }, size: 10_000 } }
+      let(:expected_inner_terms) { { field: "some.field.keyword", size: 10_000 } }
 
       it "includes the size in the inner terms" do
         expect(term).to eq(expected_term)
@@ -95,37 +92,35 @@ RSpec.describe ElasticsearchModels::Query::AggregationTerm do
     context "when order is provided" do
       context "as a string" do
         let(:order) { "_key" }
-        let(:expected_inner_terms) { { field: "some.field.keyword", order: { "_key" => "desc" } } }
+        let(:expected_inner_terms) { { field: "some.field.keyword", order: [{ "_key" => "desc" }] } }
 
         it "orders by provided field with a default sort direction" do
           expect(term).to eq(expected_term)
         end
       end
 
-      context "as an array" do
-        context "with a single element" do
-          let(:order) { ["_key"] }
-          let(:expected_inner_terms) { { field: "some.field.keyword", order: { "_key" => "desc" } } }
+      context "as a hash" do
+        let(:order) { { "_key" => "asc" } }
+        let(:expected_inner_terms) { { field: "some.field.keyword", order: [{ "_key" => "asc" }] } }
 
-          it "orders by provided term with a default sort direction" do
-            expect(term).to eq(expected_term)
-          end
+        it "orders by provided field with provided sort direction" do
+          expect(term).to eq(expected_term)
         end
+      end
 
-        context "with two elements" do
-          let(:order) { ["_key", "asc"] }
-          let(:expected_inner_terms) { { field: "some.field.keyword", order: { "_key" => "asc" } } }
+      context "as an array" do
+        let(:order) { ["_key", { "_count" => "asc" }] }
+        let(:expected_inner_terms) { { field: "some.field.keyword", order: [{ "_key" => "desc" }, { "_count" => "asc" }] } }
 
-          it "orders by provided term and sorts by the provided sort direction" do
-            expect(term).to eq(expected_term)
-          end
+        it "orders by all provided orderings" do
+          expect(term).to eq(expected_term)
         end
       end
     end
 
     context "partition is provided" do
       let(:partition) { 1 }
-      let(:expected_inner_terms) { { field: "some.field.keyword", order: { "_count" => "desc" }, include: { partition: 1 } } }
+      let(:expected_inner_terms) { { field: "some.field.keyword", include: { partition: 1 } } }
 
       it "nests partition under include key within inner terms" do
         expect(term).to eq(expected_term)
@@ -134,7 +129,7 @@ RSpec.describe ElasticsearchModels::Query::AggregationTerm do
 
     context "num_partitions is provided" do
       let(:num_partitions) { 1 }
-      let(:expected_inner_terms) { { field: "some.field.keyword", order: { "_count" => "desc" }, include: { num_partitions: 1 } } }
+      let(:expected_inner_terms) { { field: "some.field.keyword", include: { num_partitions: 1 } } }
 
       it "nests num_partitions under include key" do
         expect(term).to eq(expected_term)
@@ -144,7 +139,7 @@ RSpec.describe ElasticsearchModels::Query::AggregationTerm do
     context "partition and num_partitions are provided within inner terms" do
       let(:partition) { 1 }
       let(:num_partitions) { 1 }
-      let(:expected_inner_terms) { { field: "some.field.keyword", order: { "_count" => "desc" }, include: { partition: 1, num_partitions: 1 } } }
+      let(:expected_inner_terms) { { field: "some.field.keyword", include: { partition: 1, num_partitions: 1 } } }
 
       it "nests values under include key within inner terms" do
         expect(term).to eq(expected_term)

--- a/spec/query/aggregations_spec.rb
+++ b/spec/query/aggregations_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe ElasticsearchModels::Query::Aggregations do
           aggs: {
             "some.field.keyword" => {
               terms: {
-                field: "some.field.keyword",
-                order: { "_count" => "desc" }
+                field: "some.field.keyword"
               }
             }
           }
@@ -33,14 +32,12 @@ RSpec.describe ElasticsearchModels::Query::Aggregations do
             aggs: {
               "some.field.keyword" => {
                 terms: {
-                  field: "some.field.keyword",
-                  order: { "_count" => "desc" }
+                  field: "some.field.keyword"
                 }
               },
               "some.field.integer" => {
                 terms: {
-                  field: "some.field.integer",
-                  order: { "_count" => "desc" }
+                  field: "some.field.integer"
                 }
               }
             }
@@ -59,13 +56,12 @@ RSpec.describe ElasticsearchModels::Query::Aggregations do
                 terms: {
                   field: "some.field.keyword",
                   size:  10_000,
-                  order: { "_key" => "desc" }
+                  order: [{ "_key" => "desc" }]
                 }
               },
               "some.field.integer" => {
                 terms: {
-                  field: "some.field.integer",
-                  order: { "_count" => "desc" }
+                  field: "some.field.integer"
                 }
               }
             }
@@ -82,20 +78,17 @@ RSpec.describe ElasticsearchModels::Query::Aggregations do
             aggs: {
               "some.field.keyword" => {
                 terms: {
-                  field: "some.field.keyword",
-                  order: { "_count" => "desc" }
+                  field: "some.field.keyword"
                 }
               },
               "some.int" => {
                 terms: {
-                  field: "some.int",
-                  order: { "_count" => "desc" }
+                  field: "some.int"
                 }
               },
               "some.other.int" => {
                 terms: {
-                  field: "some.other.int",
-                  order: { "_count" => "desc" }
+                  field: "some.other.int"
                 }
               }
             }
@@ -130,7 +123,7 @@ RSpec.describe ElasticsearchModels::Query::Aggregations do
                 terms: {
                   field: "some.field.keyword",
                   size: 10_000,
-                  order: { "_key" => "desc" }
+                  order: [{ "_key" => "desc" }]
                 }
               }
             }
@@ -149,13 +142,12 @@ RSpec.describe ElasticsearchModels::Query::Aggregations do
                     terms: {
                       field: "some.field.keyword",
                       size: 10_000,
-                      order: { "_key" => "desc" }
+                      order: [{ "_key" => "desc" }]
                     },
                     aggs: {
                       "some.field.id" => {
                         terms: {
-                          field: "some.field.id",
-                          order: { "_count" => "desc" }
+                          field: "some.field.id"
                         }
                       }
                     }
@@ -176,14 +168,13 @@ RSpec.describe ElasticsearchModels::Query::Aggregations do
                     terms: {
                       field: "some.field.keyword",
                       size: 10_000,
-                      order: { "_key" => "desc" }
+                      order: [{ "_key" => "desc" }]
                     },
                     aggs: {
                       "some.field.id" => {
                         terms: {
                           field: "some.field.id",
-                          size: 20,
-                          order: { "_count" => "desc" }
+                          size: 20
                         }
                       }
                     }
@@ -204,19 +195,17 @@ RSpec.describe ElasticsearchModels::Query::Aggregations do
                     terms: {
                       field: "some.field.keyword",
                       size: 10_000,
-                      order: { "_key" => "desc" }
+                      order: [{ "_key" => "desc" }]
                     },
                     aggs: {
                       "some.field.id" => {
                         terms: {
-                          field: "some.field.id",
-                          order: { "_count" => "desc" }
+                          field: "some.field.id"
                         }
                       },
                       "some.field.other" => {
                         terms: {
-                          field: "some.field.other",
-                          order: { "_count" => "desc" }
+                          field: "some.field.other"
                         }
                       }
                     }

--- a/spec/query/aggregations_spec.rb
+++ b/spec/query/aggregations_spec.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+
+RSpec.describe ElasticsearchModels::Query::Aggregations do
+  describe ".terms_for" do
+    subject(:terms) { ElasticsearchModels::Query::Aggregations.terms_for(condition) }
+
+    let(:condition) { }
+
+    context "when condition is a String" do
+      let(:condition) { "some.field.keyword" }
+
+      it "builds a single aggregation term" do
+        expected_terms = {
+          aggs: {
+            "some.field.keyword" => {
+              terms: {
+                field: "some.field.keyword",
+                order: { "_count" => "desc" }
+              }
+            }
+          }
+        }
+        expect(terms).to eq(expected_terms)
+      end
+    end
+
+    context "when condition is an Array" do
+      let(:condition) { ["some.field.keyword", "some.field.integer"] }
+
+      context "and a value is a String" do
+        it "builds aggregation terms with wide sub aggregations" do
+          expected_terms = {
+            aggs: {
+              "some.field.keyword" => {
+                terms: {
+                  field: "some.field.keyword",
+                  order: { "_count" => "desc" }
+                }
+              },
+              "some.field.integer" => {
+                terms: {
+                  field: "some.field.integer",
+                  order: { "_count" => "desc" }
+                }
+              }
+            }
+          }
+          expect(terms).to eq(expected_terms)
+        end
+      end
+
+      context "and a value is a Hash" do
+        let(:condition) { [{ field: "some.field.keyword", size: 10_000, order: "_key" }, "some.field.integer"] }
+
+        it "builds aggregation terms with provided options" do
+          expected_terms = {
+            aggs: {
+              "some.field.keyword" => {
+                terms: {
+                  field: "some.field.keyword",
+                  size:  10_000,
+                  order: { "_key" => "desc" }
+                }
+              },
+              "some.field.integer" => {
+                terms: {
+                  field: "some.field.integer",
+                  order: { "_count" => "desc" }
+                }
+              }
+            }
+          }
+          expect(terms).to eq(expected_terms)
+        end
+      end
+
+      context "and a value is an Array" do
+        let(:condition) { ["some.field.keyword", ["some.int", "some.other.int"]] }
+
+        it "should flatten array and build terms" do
+          expected_terms = {
+            aggs: {
+              "some.field.keyword" => {
+                terms: {
+                  field: "some.field.keyword",
+                  order: { "_count" => "desc" }
+                }
+              },
+              "some.int" => {
+                terms: {
+                  field: "some.int",
+                  order: { "_count" => "desc" }
+                }
+              },
+              "some.other.int" => {
+                terms: {
+                  field: "some.other.int",
+                  order: { "_count" => "desc" }
+                }
+              }
+            }
+          }
+          expect(terms).to eq(expected_terms)
+        end
+      end
+
+      context "with duplicate fields" do
+        let(:condition) { ["some.field.keyword"] * 2 }
+        it "raises ArgumentError" do
+          expect { terms }.to raise_error(ArgumentError, "duplicate field aggregation provided for \"some.field.keyword\"")
+        end
+      end
+    end
+
+    context "when condition is a Hash" do
+      context "and field is not provided" do
+        let(:condition) { { size: 10_000 } }
+        it "raises an ArgumentError" do
+          expect { terms }.to raise_error(ArgumentError, "missing keyword: field")
+        end
+      end
+
+      context "and field is provided" do
+        let(:condition) { { field: "some.field.keyword", size: 10_000, order: "_key" } }
+
+        it "builds aggregation terms with the provided options" do
+          expected_terms = {
+            aggs: {
+              "some.field.keyword" => {
+                terms: {
+                  field: "some.field.keyword",
+                  size: 10_000,
+                  order: { "_key" => "desc" }
+                }
+              }
+            }
+          }
+          expect(terms).to eq(expected_terms)
+        end
+
+        context "with aggs option" do
+          let(:condition) { { field: "some.field.keyword", size: 10_000, order: "_key", aggs: "some.field.id" } }
+
+          context "and value is a String" do
+            it "builds aggregation terms with a single sub aggregation" do
+              expected_terms = {
+                aggs: {
+                  "some.field.keyword" => {
+                    terms: {
+                      field: "some.field.keyword",
+                      size: 10_000,
+                      order: { "_key" => "desc" }
+                    },
+                    aggs: {
+                      "some.field.id" => {
+                        terms: {
+                          field: "some.field.id",
+                          order: { "_count" => "desc" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+              expect(terms).to eq(expected_terms)
+            end
+          end
+
+          context "and value is a Hash" do
+            let(:condition) { { field: "some.field.keyword", size: 10_000, order: "_key", aggs: { field: "some.field.id", size: 20 } } }
+
+            it "also builds sub aggregation terms with provided options" do
+              expected_terms = {
+                aggs: {
+                  "some.field.keyword" => {
+                    terms: {
+                      field: "some.field.keyword",
+                      size: 10_000,
+                      order: { "_key" => "desc" }
+                    },
+                    aggs: {
+                      "some.field.id" => {
+                        terms: {
+                          field: "some.field.id",
+                          size: 20,
+                          order: { "_count" => "desc" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+              expect(terms).to eq(expected_terms)
+            end
+          end
+
+          context "and value is an Array" do
+            let(:condition) { { field: "some.field.keyword", size: 10_000, order: "_key", aggs: ["some.field.id", "some.field.other"] } }
+
+            it "builds aggregation terms with many sub aggregations" do
+              expected_terms = {
+                aggs: {
+                  "some.field.keyword" => {
+                    terms: {
+                      field: "some.field.keyword",
+                      size: 10_000,
+                      order: { "_key" => "desc" }
+                    },
+                    aggs: {
+                      "some.field.id" => {
+                        terms: {
+                          field: "some.field.id",
+                          order: { "_count" => "desc" }
+                        }
+                      },
+                      "some.field.other" => {
+                        terms: {
+                          field: "some.field.other",
+                          order: { "_count" => "desc" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+              expect(terms).to eq(expected_terms)
+            end
+          end
+        end
+      end
+
+      context "with unexpected options" do
+        let(:condition) { { field: "some.field.keyword", invalid: "key" } }
+
+        it "raises an ArgumentError" do
+          expect { terms }.to raise_error(ArgumentError, "unknown keyword: invalid")
+        end
+      end
+    end
+
+    context "when condition is anything else" do
+      let(:condition) { 1 }
+
+      it "raises an ArgumentError" do
+        expect { terms }.to raise_error(ArgumentError, "unexpected condition type: got 1")
+      end
+    end
+  end
+end

--- a/spec/query/builder_spec.rb
+++ b/spec/query/builder_spec.rb
@@ -373,8 +373,7 @@ RSpec.describe ElasticsearchModels::Query::Builder do
         {
           "some.field.keyword" => {
             terms: {
-              field: "some.field.keyword",
-              order: { "_count" => "desc" }
+              field: "some.field.keyword"
             }
           }
         }

--- a/spec/query/builder_spec.rb
+++ b/spec/query/builder_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe ElasticsearchModels::Query::Builder do
-  def expected_query_body(bool_body: nil, sort_by_inner_body: nil)
+  def expected_query_body(bool_body: nil, sort_by_inner_body: nil, aggs_inner_body: nil)
     query_body   = bool_body.present? ? { query: { bool: bool_body } } : {}
     sort_by_body = sort_by_inner_body.present? ? { sort: sort_by_inner_body } : {}
-
-    @default_expected_params.merge(body: [query_body, sort_by_body].reduce(&:merge))
+    aggs_body = aggs_inner_body.present? ? { aggs: aggs_inner_body } : {}
+    @default_expected_params.merge(body: [query_body, sort_by_body, aggs_body].reduce(&:merge))
   end
 
   def new_builder(**params)
@@ -362,6 +362,41 @@ RSpec.describe ElasticsearchModels::Query::Builder do
         expected_params = expected_query_body(bool_body: bool_body)
         params = { term1: true, term2: { a: { b: 1, c: 2 } }, term3: [1, { a: { b: 2, c: { d: (1..2) } } }], term4: [:a, :b] }
         expect(new_builder(params).search_params).to eq(expected_params)
+      end
+    end
+
+    context "with _aggs provided" do
+      subject(:search_params) { new_builder(search_options).search_params }
+      let(:search_options) { { _aggs: _aggs } }
+      let(:_aggs) { "some.field.keyword" }
+      let(:expected_inner_aggs) do
+        {
+          "some.field.keyword" => {
+            terms: {
+              field: "some.field.keyword",
+              order: { "_count" => "desc" }
+            }
+          }
+        }
+      end
+
+      it "includes aggs in body" do
+        expect(search_params).to eq(expected_query_body(aggs_inner_body: expected_inner_aggs))
+      end
+
+      context "and a search query" do
+        let(:search_options) { { _aggs: _aggs, _q: "text search" } }
+
+        it "includes the query_string in bool body with aggregations built" do
+          expected_bool_body = {
+            must: [
+              query_string: {
+                query: '(*text AND search*)'
+              }
+            ]
+          }
+          expect(search_params).to eq(expected_query_body(aggs_inner_body: expected_inner_aggs, bool_body: expected_bool_body))
+        end
       end
     end
   end


### PR DESCRIPTION
https://ringrevenue.atlassian.net/browse/STORY-7120

## Included in this PR
* `ElasticsearchModels::Query::AggregateTerm` PORO
  * handles some validation on aggregation terms
* `ElasticsearchModels::Query::Aggregations` PORO
  * recursively builds Aggregation terms to be used in a search
* Integration into the `ElasticsearchModels::Query::Builder`
* `ElasticsearchModels::Base.distinct_values`