### PR TITLE
No jira update hash json default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "aggregate",         "~> 1.2",   git: "git@github.com:Invoca/aggregate.git",         ref: "cf0d3e635e3847c39bee190e9dd597e4f958e44c"
+gem "aggregate",         "~> 1.2",   git: "git@github.com:Invoca/aggregate.git",         ref: "a575767a915acf4270d807a2d3439b0d7ea74212"
 gem "hobo_support",         "2.0.1", git: "git@github.com:Invoca/hobosupport",           ref: "b9086322274b474a2b5bae507c4885e55d4aa050"
 gem "large_text_field",              git: "git@github.com:Invoca/large_text_field.git",  ref: "2efc950395352bf8b7f45891122f6bc42b171526"
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "aggregate",         "~> 1.0.1", git: "git@github.com:Invoca/aggregate.git",         ref: "4644394a818295f240f22ae2cee2a92a9fd4f605"
+gem "aggregate",         "~> 1.2",   git: "git@github.com:Invoca/aggregate.git",         ref: "cf0d3e635e3847c39bee190e9dd597e4f958e44c"
 gem "hobo_support",         "2.0.1", git: "git@github.com:Invoca/hobosupport",           ref: "b9086322274b474a2b5bae507c4885e55d4aa050"
 gem "large_text_field",              git: "git@github.com:Invoca/large_text_field.git",  ref: "2efc950395352bf8b7f45891122f6bc42b171526"
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "aggregate",         "~> 1.2",   git: "git@github.com:Invoca/aggregate.git",         ref: "a575767a915acf4270d807a2d3439b0d7ea74212"
+gem "aggregate",         "~> 1.2",   git: "git@github.com:Invoca/aggregate.git",         ref: "7bd5ca88cc71785d50623e4644aaa7ad703b2c87"
 gem "hobo_support",         "2.0.1", git: "git@github.com:Invoca/hobosupport",           ref: "b9086322274b474a2b5bae507c4885e55d4aa050"
 gem "large_text_field",              git: "git@github.com:Invoca/large_text_field.git",  ref: "2efc950395352bf8b7f45891122f6bc42b171526"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git@github.com:Invoca/aggregate.git
-  revision: a575767a915acf4270d807a2d3439b0d7ea74212
-  ref: a575767a915acf4270d807a2d3439b0d7ea74212
+  revision: 7bd5ca88cc71785d50623e4644aaa7ad703b2c87
+  ref: 7bd5ca88cc71785d50623e4644aaa7ad703b2c87
   specs:
     aggregate (1.2)
       activerecord (~> 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: git@github.com:Invoca/aggregate.git
-  revision: 4644394a818295f240f22ae2cee2a92a9fd4f605
-  ref: 4644394a818295f240f22ae2cee2a92a9fd4f605
+  revision: cf0d3e635e3847c39bee190e9dd597e4f958e44c
+  ref: cf0d3e635e3847c39bee190e9dd597e4f958e44c
   specs:
-    aggregate (1.0.1)
+    aggregate (1.2)
       activerecord (~> 4.0)
       encryptor (~> 3.0)
       hobo_support (= 2.0.1)
@@ -195,7 +195,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aggregate (~> 1.0.1)!
+  aggregate (~> 1.2)!
   bundler (~> 1.16)
   elasticsearch-extensions
   elasticsearch_models!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git@github.com:Invoca/aggregate.git
-  revision: cf0d3e635e3847c39bee190e9dd597e4f958e44c
-  ref: cf0d3e635e3847c39bee190e9dd597e4f958e44c
+  revision: a575767a915acf4270d807a2d3439b0d7ea74212
+  ref: a575767a915acf4270d807a2d3439b0d7ea74212
   specs:
     aggregate (1.2)
       activerecord (~> 4.0)
@@ -30,7 +30,7 @@ GIT
 PATH
   remote: .
   specs:
-    elasticsearch_models (0.2.6)
+    elasticsearch_models (0.2.7)
       activesupport
       elasticsearch (= 6.1.0)
       hobo_support (= 2.0.1)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ All classes that you want to store as documents should inherit from `Elasticsear
 ### Full Examples
 For complete example usage, see [the spec for ElasticsearchModels::Base]("https://github.com/Invoca/elasticsearch_models/blob/master/spec/base_spec.rb").
 
-Note: `rehydration_class` and `query_types` are fields used internally in `ElasticsearchModels::Base` so they should not be changed.
+Notes:
+* `rehydration_class` and `query_types` are fields used internally in `ElasticsearchModels::Base` so they should not be changed.
+* `hash` fields are stored as JSON blobs, meaning they are not queryable and can not be used for sorting. If necessary, use a nested class with named fields.
+
 
 ### Creating a model
 _create!_ will build and validate a model and then insert the model into Elasticsearch:
@@ -72,7 +75,7 @@ model = DummyElasticSearchModel.new(my_string: "Hi")
 model.save!
 ```
 
-Unlike active record, you cannot update an existing model.  
+Unlike active record, you cannot update an existing model.
 
 #### `#new_record?`
 
@@ -98,7 +101,7 @@ response = DummyElasticSearchModel.insert!(model.deep_squash_to_store, model.ind
 DummyElasticSearchModel.insert!(model.deep_squash_to_store, model.index_name)
 => raises ElasticsearchModels::Base::CreateError
 
-# Non-Hash value passed in for first argument"" 
+# Non-Hash value passed in for first argument""
 DummyElasticSearchModel.insert!("abc", model.index_name)
 => raises RuntimeError
 ```
@@ -135,8 +138,8 @@ DummyElasticSearchModel.where(my_string: "Hi", my_int: [1, 2])
 # Query by attributes that must match and attributes that should match at least 1 value (can include ranges)
 DummyElasticSearchModel.where(my_string: "Hi", my_int: [1, (5..10)])
 
-# Query by matching nested classes and or hash fields
-DummyElasticSearchModel.where(my_nested_class: { nested_hash_field: { a: 1, b: 2 } })
+# Query by matching nested class fields (hashes and nested hashes are not queryable by default)
+DummyElasticSearchModel.where(my_nested_class: { nested_int_field: 5 })
 ```
 
 #### Adding sorting to queries
@@ -148,7 +151,7 @@ DummyElasticSearchModel.where(my_string: "Hi", _sort_by: { my_time: :asc })
 # Sort by multiple attributes
 DummyElasticSearchModel.where(_sort_by: [{ my_int: :desc }, { my_time: :asc }])
 
-# Sort by nested classes and hash fields
+# Sort by nested class fields (can not sort by fields in hashes and nested hashes by default)
 DummyElasticSearchModel.where(_sort_by: [{ "my_nested_class.nested_hash_field.a.b" => :desc })
 ```
 
@@ -181,8 +184,8 @@ DummyElasticSearchModel.where(_q: { my_string: "Hi", my_int: 5..10) })
 # Query by attributes where at least 1 value matches
 DummyElasticSearchModel.where(_q: { my_string: "Hi", my_int: [1, (5..10)] })
 
-# Query by nested classes or hash fields
-DummyElasticSearchModel.where(_q: { my_nested_class: { nested_hash_field: { a: 1, b: 2 } } })
+# Query by nested class fields (hashes and nested hashes are not queryable by default)
+DummyElasticSearchModel.where(_q: { my_nested_class: { nested_string_field: "Hey" })
 ```
 
 #### Querying with Inheritance

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ response = DummyElasticSearchModel.insert!(model.deep_squash_to_store, model.ind
 DummyElasticSearchModel.insert!(model.deep_squash_to_store, model.index_name)
 => raises ElasticsearchModels::Base::CreateError
 
-# Non-Hash value passed in for first argument""
+# Non-Hash value passed in for first argument
 DummyElasticSearchModel.insert!("abc", model.index_name)
 => raises RuntimeError
 ```

--- a/lib/elasticsearch_models/version.rb
+++ b/lib/elasticsearch_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ElasticsearchModels
-  VERSION = "0.2.6"
+  VERSION = "0.2.7"
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -950,18 +950,6 @@ RSpec.describe ElasticsearchModels::Base do
           expect(query_response.models.first.to_store).to eq(dummy_model.to_store)
         end
 
-        # it "filters by matching hash" do
-        #   # This is assuming the hash has the option `store_hash_as_json: false`
-        #   # Note: returned hashes will have stringified keys regardless of the input format
-        #   dummy_model = DummyElasticSearchModel.create!(my_string: "Hello", my_hash: { a: { b: 1, c: 1 } })
-        #   DummyElasticSearchModel.create!(my_string: "Hello", my_hash: { a: { b: 1, c: 2 } })
-        #   refresh_index
-
-        #   query_response = DummyElasticSearchModel.where(my_hash: { a: { b: 1, c: 1 } })
-        #   expect(query_response.models.count).to eq(1)
-        #   expect(query_response.models.first.to_store).to eq(dummy_model.to_store.deep_stringify_keys)
-        # end
-
         it "filters by matching nested class" do
           nested_bool_true  = DummyElasticSearchModel::NestedAggregateAttribute::NestedBoolAttribute.new(nested_bool: true)
           nested_bool_false = DummyElasticSearchModel::NestedAggregateAttribute::NestedBoolAttribute.new(nested_bool: false)
@@ -1087,26 +1075,6 @@ RSpec.describe ElasticsearchModels::Base do
           query_response3 = DummyElasticSearchModel.where(my_decimal: Range.new(BigDecimal(6), BigDecimal(4)))
           expect(query_response3.models.count).to eq(0)
         end
-
-        # it "filters by nested hash int range" do
-        #   # This is assuming the hash has the option `store_hash_as_json: false`
-        #   dummy_model = DummyElasticSearchModel.create!(my_string: "Hello", my_hash: { a: { b: 1, c: 5 } })
-        #   DummyElasticSearchModel.create!(my_string: "Hello", my_hash: { a: { b: 1, c: 1 } })
-        #   DummyElasticSearchModel.create!(my_string: "Hello", my_hash: { a: { b: 1, c: 10 } })
-        #   DummyElasticSearchModel.create!(my_string: "Hello")
-        #   refresh_index
-
-        #   query_response1 = DummyElasticSearchModel.where(my_hash: { a: { b: 1, c: Range.new(4, 6) } })
-        #   expect(query_response1.models.count).to eq(1)
-        #   expect(query_response1.models.first.to_store).to eq(dummy_model.to_store.deep_stringify_keys)
-
-        #   query_response2 = DummyElasticSearchModel.where(my_hash: { a: { b: 1, c: Range.new(5, 5) } })
-        #   expect(query_response2.models.count).to eq(1)
-        #   expect(query_response2.models.first.to_store).to eq(dummy_model.to_store.deep_stringify_keys)
-
-        #   query_response3 = DummyElasticSearchModel.where(my_hash: { a: { b: 1, c: Range.new(6, 4) } })
-        #   expect(query_response3.models.count).to eq(0)
-        # end
 
         it "filters by nested class int range" do
           shared_fields = { nested_string_field: "Hi" }


### PR DESCRIPTION
### Details
* Update `aggregate` sha to use updated version where `store_hash_as_json` defaults to `true` regardless of storage type.
  * This is so that elasticsearch models will by default store hash fields as JSON blobs without requiring `store_hash_as_json: true` to be set. This is to avoid inadvertently falling into the problem where a hash attribute creates an unnamed Elasticsearch document field which is untracked and may easily cause a field name collision.

Aggregate PR: https://github.com/Invoca/aggregate/pull/34