### PR TITLE
No-Jira: relax hobo_support version constraint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 gemspec
 
 gem "aggregate",         "~> 1.2",   git: "git@github.com:Invoca/aggregate.git",         ref: "6fc589319401c06d0c9dd33af25c8731bd9c1f7c"
-gem "large_text_field", '0.3.0.pre.1'
 
 group :development do
   gem 'rubocop', '0.74.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,8 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "aggregate",         "~> 1.2",   git: "git@github.com:Invoca/aggregate.git",         ref: "7bd5ca88cc71785d50623e4644aaa7ad703b2c87"
-gem "hobo_support",         "2.0.1", git: "git@github.com:Invoca/hobosupport",           ref: "b9086322274b474a2b5bae507c4885e55d4aa050"
-gem "large_text_field",              git: "git@github.com:Invoca/large_text_field.git",  ref: "2efc950395352bf8b7f45891122f6bc42b171526"
+gem "aggregate",         "~> 1.2",   git: "git@github.com:Invoca/aggregate.git",         ref: "6fc589319401c06d0c9dd33af25c8731bd9c1f7c"
+gem "large_text_field", '0.3.0.pre.1'
 
 group :development do
   gem 'rubocop', '0.74.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
-    large_text_field (0.3.0.pre.1)
+    large_text_field (0.3.0)
       hobo_support (~> 2.2)
       protected_attributes (~> 1.1)
       rails (~> 4.2)
@@ -187,7 +187,6 @@ DEPENDENCIES
   bundler (~> 1.16)
   elasticsearch-extensions
   elasticsearch_models!
-  large_text_field (= 0.3.0.pre.1)
   pry
   pry-byebug
   rake (~> 10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,39 +1,21 @@
 GIT
   remote: git@github.com:Invoca/aggregate.git
-  revision: 7bd5ca88cc71785d50623e4644aaa7ad703b2c87
-  ref: 7bd5ca88cc71785d50623e4644aaa7ad703b2c87
+  revision: 6fc589319401c06d0c9dd33af25c8731bd9c1f7c
+  ref: 6fc589319401c06d0c9dd33af25c8731bd9c1f7c
   specs:
     aggregate (1.2)
       activerecord (~> 4.0)
       encryptor (~> 3.0)
-      hobo_support (= 2.0.1)
+      hobo_support (~> 2.2)
       large_text_field (~> 0.2)
-
-GIT
-  remote: git@github.com:Invoca/hobosupport
-  revision: b9086322274b474a2b5bae507c4885e55d4aa050
-  ref: b9086322274b474a2b5bae507c4885e55d4aa050
-  specs:
-    hobo_support (2.0.1)
-      rails (~> 4.2.10)
-
-GIT
-  remote: git@github.com:Invoca/large_text_field.git
-  revision: 2efc950395352bf8b7f45891122f6bc42b171526
-  ref: 2efc950395352bf8b7f45891122f6bc42b171526
-  specs:
-    large_text_field (0.2.0)
-      hobo_support (= 2.0.1)
-      protected_attributes
-      rails (~> 4.2)
 
 PATH
   remote: .
   specs:
-    elasticsearch_models (1.0.0)
+    elasticsearch_models (1.0.1)
       activesupport
       elasticsearch (= 6.1.0)
-      hobo_support (= 2.0.1)
+      hobo_support (~> 2.2)
       large_text_field (~> 0.2)
 
 GEM
@@ -79,8 +61,8 @@ GEM
     builder (3.2.4)
     byebug (11.0.1)
     coderay (1.1.2)
-    concurrent-ruby (1.1.5)
-    crass (1.0.5)
+    concurrent-ruby (1.1.6)
+    crass (1.0.6)
     diff-lcs (1.3)
     elasticsearch (6.1.0)
       elasticsearch-api (= 6.1.0)
@@ -99,9 +81,15 @@ GEM
       multipart-post (>= 1.2, < 3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hobo_support (2.2.6)
+      rails (~> 4.2.6)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    large_text_field (0.3.0.pre.1)
+      hobo_support (~> 2.2)
+      protected_attributes (~> 1.1)
+      rails (~> 4.2)
     loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -110,10 +98,10 @@ GEM
     method_source (0.9.2)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.13.0)
+    minitest (5.14.0)
     multi_json (1.14.1)
     multipart-post (2.1.1)
-    nokogiri (1.10.7)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     parallel (1.19.1)
     parser (2.7.0.2)
@@ -126,7 +114,7 @@ GEM
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    rack (1.6.12)
+    rack (1.6.13)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.11.1)
@@ -199,8 +187,7 @@ DEPENDENCIES
   bundler (~> 1.16)
   elasticsearch-extensions
   elasticsearch_models!
-  hobo_support (= 2.0.1)!
-  large_text_field!
+  large_text_field (= 0.3.0.pre.1)
   pry
   pry-byebug
   rake (~> 10.0)

--- a/elasticsearch_models.gemspec
+++ b/elasticsearch_models.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport"
   s.add_dependency 'elasticsearch', '6.1.0'
-  s.add_dependency "hobo_support",     "2.0.1"
+  s.add_dependency "hobo_support",     "~> 2.2"
   s.add_dependency "large_text_field", "~> 0.2"
 
   s.add_development_dependency "bundler", "~> 1.16"


### PR DESCRIPTION
This is necessary to unblock our Gemfury conversion.

