### PR TITLE
No-Jira: relax hobo_support version constraint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ PATH
     elasticsearch_models (1.0.1)
       activesupport
       elasticsearch (= 6.1.0)
-      hobo_support (~> 2.2)
+      hobo_support (~> 2.0)
       large_text_field (~> 0.2)
 
 GEM

--- a/elasticsearch_models.gemspec
+++ b/elasticsearch_models.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport"
   s.add_dependency 'elasticsearch', '6.1.0'
-  s.add_dependency "hobo_support",     "~> 2.2"
+  s.add_dependency "hobo_support",     "~> 2.0"
   s.add_dependency "large_text_field", "~> 0.2"
 
   s.add_development_dependency "bundler", "~> 1.16"


### PR DESCRIPTION
These changes needed to unblock downstream consumers.

This gem doesn't care what version of hobo_support is available, so long as version >= 2.0.0 is available.